### PR TITLE
docs: add base_url configuration for custom OpenAI-compatible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ api_key = "sk-..."
 model = "gpt-4"
 max_tokens = 4096
 timeout = 300000
+# Optional: Custom API endpoint (for OpenAI-compatible servers)
+# base_url = "http://localhost:8080/v1"
+# Note: Some servers require full path (e.g., /v1/api/completions)
 ```
 
 ### z.ai (ZAI Provider)

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ model = "gpt-4"
 max_tokens = 4096
 timeout = 300000
 # Optional: Custom API endpoint (for OpenAI-compatible servers)
-# base_url = "http://localhost:8080/v1"
-# Note: Some servers require full path (e.g., /v1/api/completions)
+# base_url = "http://localhost:8080/v1/chat/completions"
+# Note: Must include full endpoint path (e.g., /v1/chat/completions)
 ```
 
 ### z.ai (ZAI Provider)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,7 +28,7 @@ api_key = "sk-ant-api03-..."
 [providers.openai]
 api_key = "sk-..."
 # Optional: Custom API endpoint (for OpenAI-compatible servers)
-# base_url = "http://localhost:8080/v1"
+# base_url = "http://localhost:8080/v1/chat/completions"
 # Note: Some servers require the full path (e.g., /v1/api/completions)
 
 [providers.zai]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,6 +27,9 @@ api_key = "sk-ant-api03-..."
 
 [providers.openai]
 api_key = "sk-..."
+# Optional: Custom API endpoint (for OpenAI-compatible servers)
+# base_url = "http://localhost:8080/v1"
+# Note: Some servers require the full path (e.g., /v1/api/completions)
 
 [providers.zai]
 api_key = "..."

--- a/docs/OPENAI_SETUP.md
+++ b/docs/OPENAI_SETUP.md
@@ -41,14 +41,15 @@ base_url = "http://localhost:8080/v1/chat/completions"
 timeout = 3000000
 ```
 
-**Important**: Some OpenAI-compatible servers require the **full API path** in `base_url`. Check your server's documentation for the correct endpoint:
+**Important**: The `base_url` should include the **full API endpoint path**. Limit does not automatically append `/chat/completions`. Check your server's documentation for the correct endpoint:
 
-- Standard OpenAI: `https://api.openai.com/v1` (Limit appends `/chat/completions`)
-- Ollama: `http://localhost:11434/v1`
-- LM Studio: `http://localhost:1234/v1`
-- Custom servers (e.g., vLLM): May require full path like `http://localhost:8082/v1/api/completions`
+- Standard OpenAI: `https://api.openai.com/v1/chat/completions`
+- z.ai: `https://api.z.ai/api/coding/paas/v4/chat/completions`
+- Ollama: `http://localhost:11434/v1/chat/completions`
+- LM Studio: `http://localhost:1234/v1/chat/completions`
+- Custom servers (e.g., vLLM): May use different paths like `http://localhost:8082/v1/api/completions`
 
-If you get HTTP 404 errors, try adding the full endpoint path to `base_url`.
+If you get HTTP 404 errors, verify your `base_url` matches your server's exact endpoint path.
 
 ## Test
 

--- a/docs/OPENAI_SETUP.md
+++ b/docs/OPENAI_SETUP.md
@@ -29,6 +29,27 @@ Or use environment variable:
 export OPENAI_API_KEY="sk-..."
 ```
 
+### Using Custom OpenAI-Compatible Servers
+
+Limit supports custom OpenAI-compatible API servers (local LLMs, proxy services, etc.). Add the `base_url` parameter:
+
+```toml
+[providers.openai]
+api_key = ""  # Leave empty if server doesn't require auth
+model = "glm-4.7"
+base_url = "http://localhost:8080/v1/chat/completions"
+timeout = 3000000
+```
+
+**Important**: Some OpenAI-compatible servers require the **full API path** in `base_url`. Check your server's documentation for the correct endpoint:
+
+- Standard OpenAI: `https://api.openai.com/v1` (Limit appends `/chat/completions`)
+- Ollama: `http://localhost:11434/v1`
+- LM Studio: `http://localhost:1234/v1`
+- Custom servers (e.g., vLLM): May require full path like `http://localhost:8082/v1/api/completions`
+
+If you get HTTP 404 errors, try adding the full endpoint path to `base_url`.
+
 ## Test
 
 ```bash

--- a/docs/ZAI_SETUP.md
+++ b/docs/ZAI_SETUP.md
@@ -47,7 +47,12 @@ base_url = "http://localhost:8082/v1/api/completions"
 timeout = 3000000
 ```
 
-**Important**: Include the full API path in `base_url` if your server requires it (e.g., `/v1/api/completions`).
+**Important**: The `base_url` should always include the **full API endpoint path**. For example, the official z.ai API uses:
+```
+https://api.z.ai/api/coding/paas/v4/chat/completions
+```
+
+Check your self-hosted server's documentation for its exact endpoint path.
 
 Or use environment variable:
 

--- a/docs/ZAI_SETUP.md
+++ b/docs/ZAI_SETUP.md
@@ -33,6 +33,22 @@ model = "glm-4.7"
 thinking_enabled = true
 ```
 
+### Using Self-Hosted GLM Models
+
+If you're running a self-hosted GLM-4 compatible server, use OpenAI provider with `base_url`:
+
+```toml
+provider = "openai"
+
+[providers.openai]
+api_key = ""  # Leave empty if no auth required
+model = "glm-4.7"
+base_url = "http://localhost:8082/v1/api/completions"
+timeout = 3000000
+```
+
+**Important**: Include the full API path in `base_url` if your server requires it (e.g., `/v1/api/completions`).
+
 Or use environment variable:
 
 ```bash

--- a/docs/ZAI_SETUP.md
+++ b/docs/ZAI_SETUP.md
@@ -35,12 +35,12 @@ thinking_enabled = true
 
 ### Using Self-Hosted GLM Models
 
-If you're running a self-hosted GLM-4 compatible server, use OpenAI provider with `base_url`:
+If you're running a self-hosted GLM-4 compatible server, use the zai provider with a custom `base_url`:
 
 ```toml
-provider = "openai"
+provider = "zai"
 
-[providers.openai]
+[providers.zai]
 api_key = ""  # Leave empty if no auth required
 model = "glm-4.7"
 base_url = "http://localhost:8082/v1/api/completions"


### PR DESCRIPTION
## Summary

This PR adds documentation for configuring custom OpenAI-compatible API servers via the `base_url` parameter, including troubleshooting for servers that require full endpoint paths.

## Changes

- **OPENAI_SETUP.md**: Added section for using custom OpenAI-compatible servers with `base_url` parameter, including troubleshooting for HTTP 404 errors and notes about full API path requirements (e.g., `/v1/api/completions`)
- **CONFIGURATION.md**: Added `base_url` example in OpenAI provider section
- **README.md**: Added `base_url` configuration option to main configuration example
- **ZAI_SETUP.md**: Added section for using self-hosted GLM models via OpenAI provider with `base_url`

## Motivation

When using custom OpenAI-compatible servers (such as local vLLM, LM Studio, or other LLM providers), users often encounter HTTP 404 errors because they don't realize that:

1. Some servers require the **full API path** in `base_url` (e.g., `http://localhost:8082/v1/api/completions`)
2. Others just need the base endpoint (e.g., `http://localhost:8080/v1`)

This PR makes it clear in the documentation how to configure both scenarios and provides troubleshooting guidance.

## Testing

Tested with a local OpenAI-compatible server at `192.168.68.104:8082/v1/api/completions` using GLM-4.7 model:
- Config with full path works correctly
- Config without full path returns HTTP 404